### PR TITLE
setup.py: fix redudant dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email="gbianchi@xebia.fr",
     license='new BSD',
     packages=find_packages(),
-    install_requires=['numpy', 'pandas', 'sklearn', 'pickle', 'json', 'pydub', 'librosa'],
+    install_requires=['numpy', 'pandas', 'sklearn', 'pydub', 'librosa'],
     tests_require=['pytest', "unittest2"],
     scripts=[],
     py_modules=["baby_cry_detection"],


### PR DESCRIPTION
install_requires had 'json' and 'pickle' dependencies,
but those are standard with respect to any python distribution.

Incidentally, adding those in install_requires made the installation
fail on some configurations.

Removing those entries from the dependency list will do the job.

Signed-off-by: amunozh <andresmh96@gmail.com>